### PR TITLE
[PFMENG-581] Enable IMDSv2

### DIFF
--- a/modules/autoscaling-group/main.tf
+++ b/modules/autoscaling-group/main.tf
@@ -63,12 +63,7 @@ module "asg" {
 
   instance_market_options = var.instance_market_options
 
-  metadata_options = {
-    http_endpoint               = "enabled"
-    http_tokens                 = "required"
-    http_put_response_hop_limit = 1
-    instance_metadata_tags      = "disabled"
-  }
+  metadata_options = var.metadata_options
 
   placement = var.placement
   tags      = var.tags

--- a/modules/autoscaling-group/main.tf
+++ b/modules/autoscaling-group/main.tf
@@ -63,6 +63,13 @@ module "asg" {
 
   instance_market_options = var.instance_market_options
 
+  metadata_options = {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+    instance_metadata_tags      = "disabled"
+  }
+
   placement = var.placement
   tags      = var.tags
 }

--- a/modules/autoscaling-group/variables.tf
+++ b/modules/autoscaling-group/variables.tf
@@ -142,6 +142,22 @@ variable "instance_market_options" {
   default     = null
 }
 
+variable "metadata_options" {
+  description = "Customize the metadata options (IMDS) for the instance"
+  type = object({
+    http_endpoint               = string
+    http_tokens                 = string
+    http_put_response_hop_limit = number
+    instance_metadata_tags      = string
+  })
+  default = {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+    instance_metadata_tags      = "disabled"
+  }
+}
+
 ################################################################################
 # Autoscaling group - block
 ################################################################################


### PR DESCRIPTION
By disabling metadata_options here using `http_endpoint=disabled` it causes EC2 instances to not be able to register with ECS cluster. Instead setting `http_put_response_hop_limit=1` prevents the response from ever leaving the EC2 instance.